### PR TITLE
[exceptions] Refactored enumeration declaration and simplified exception handling 

### DIFF
--- a/include/ve/exceptions.hpp
+++ b/include/ve/exceptions.hpp
@@ -1,46 +1,43 @@
 #pragma once
 
-#include <boost/preprocessor.hpp>
+// STD
+#include <string>
+#include <cstdint>
+#include <string_view>
 
-#define X_DEFINE_ENUM_WITH_STRING_CONVERSIONS_TOSTRING_CASE(r, data, elem)    \
-    case elem : return BOOST_PP_STRINGIZE(elem);
+#define HSHARP_STRINGIFY(variable) #variable
 
-#define DEFINE_ENUM_WITH_STRING_CONVERSIONS(name, enumerators)                \
-    enum name {                                                               \
-        BOOST_PP_SEQ_ENUM(enumerators)                                        \
-    };                                                                        \
-                                                                              \
-    inline const char* ToString(name v)                                       \
-    {                                                                         \
-        switch (v)                                                            \
-        {                                                                     \
-            BOOST_PP_SEQ_FOR_EACH(                                            \
-                X_DEFINE_ENUM_WITH_STRING_CONVERSIONS_TOSTRING_CASE,          \
-                name,                                                         \
-                enumerators                                                   \
-            )                                                                 \
-            default: return "[Unknown " BOOST_PP_STRINGIZE(name) "]";         \
-        }                                                                     \
-    }
+#define HSHARP_ENUM_CASE(enum_scope, enum_value) case enum_scope::enum_value: return HSHARP_STRINGIFY(enum_value)
 
+#define HSHARP_NOT_IMPLEMENTED(scope, message) \
+    HSharpVE::error(scope, HSharpVE::EExceptionReason::NOT_IMPLEMENTED, message)
 
-namespace HSharpVE{
-DEFINE_ENUM_WITH_STRING_CONVERSIONS(ExceptionSource,
-(Tokenizer)\
-(Parser)\
-(VirtualEnv));
+namespace HSharpVE {
 
-DEFINE_ENUM_WITH_STRING_CONVERSIONS(ExceptionType,
-(SyntaxError)\
-(TypeError)\
-(InvalidAssign)\
-(NotImplemented)\
-(ConversionError)\
-(ExpressionParseError)\
-(StatementParseError)\
-(UnexpectedToken)\
-(EndOfFile));
+    // color constants
+    constexpr char RESET[] = "\033[0m";
+    constexpr char RED[] = "\033[31m";
+
+    enum class EExceptionSource : std::int_fast8_t {
+        TOKENIZER,      // Tokenizer is responsible for parsing input into chunks (tokens)
+        PARSER,         // Parser is responsible for processing tokens into viable abstraction
+        VIRTUAL_ENV,    // Runtime for parsed code
+        UTILITY,        // Utility libraries
+        // 252 more values
+    };
+
+    enum class EExceptionReason : std::int_fast8_t {
+        SYNTAX_ERROR,       // Holder for generic parser error
+        TYPE_ERROR,         // Variable type is not appropriate in current context
+        NOT_IMPLEMENTED,    // Holder for early parser versions and testing features
+        CAST_ERROR,         // Errors from casting mechanisms
+        EARLY_EOF,          // Expecting more tokens in input
+        UNEXPECTED_TOKEN    // Expecting different token
+        // 250 more values 
+    };
+
+    std::string to_string(EExceptionSource source);
+    std::string to_string(EExceptionReason reason);
+
+    [[noreturn]] void error(EExceptionSource source, EExceptionReason reason, std::string_view message);
 }
-
-[[noreturn]] void throwFatalException(HSharpVE::ExceptionSource source, HSharpVE::ExceptionType type, std::string& message);
-[[noreturn]] void throwFatalException(HSharpVE::ExceptionSource source, HSharpVE::ExceptionType type, const char* message);

--- a/include/ve/exceptions.hpp
+++ b/include/ve/exceptions.hpp
@@ -36,8 +36,8 @@ namespace HSharpVE {
         // 250 more values 
     };
 
-    std::string to_string(EExceptionSource source);
-    std::string to_string(EExceptionReason reason);
+    std::string toString(EExceptionSource source);
+    std::string toString(EExceptionReason reason);
 
     [[noreturn]] void error(EExceptionSource source, EExceptionReason reason, std::string_view message);
 }

--- a/src/parser/helpers.cpp
+++ b/src/parser/helpers.cpp
@@ -38,10 +38,10 @@ HSharpParser::Token HSharpParser::Parser::try_consume(TokenType type, int mode) 
         return consume();
     else {
         std::string msg{};
-        HSharpVE::ExceptionType exc_type;
+        HSharpVE::EExceptionReason exc_type;
         if (!peek().has_value()){
             msg.append(std::format("Unexpected EOF"));
-            exc_type = HSharpVE::EndOfFile;
+            exc_type = HSharpVE::EExceptionReason::EARLY_EOF;
         }
         else{
             msg.append(std::format( "Unexpected token type: {}, expected {}\n\tLine {}: {}\n",
@@ -49,11 +49,9 @@ HSharpParser::Token HSharpParser::Parser::try_consume(TokenType type, int mode) 
                                     HSharpParser::ToString(type),
                                     peek().value().line,
                                     lines[peek().value().line - 1].c_str()));
-            exc_type = HSharpVE::UnexpectedToken;
+            exc_type = HSharpVE::EExceptionReason::UNEXPECTED_TOKEN;
         }
-        throwFatalException(HSharpVE::ExceptionSource::Parser,
-                            exc_type,
-                            msg);
+        error(HSharpVE::EExceptionSource::PARSER, exc_type, msg);
         exit(1);
     }
 }

--- a/src/parser/tokenizer.cpp
+++ b/src/parser/tokenizer.cpp
@@ -96,9 +96,7 @@ std::vector<Token> HSharpParser::Tokenizer::tokenize() {
         } else if (std::isspace(peek().value())) {
             skip();
         } else {
-            throwFatalException(HSharpVE::ExceptionSource::Tokenizer,
-                                HSharpVE::ExceptionType::SyntaxError,
-                                "Detected invalid syntax: invalid token");
+            error(HSharpVE::EExceptionSource::TOKENIZER, HSharpVE::EExceptionReason::UNEXPECTED_TOKEN, "invalid token");
         }
     }
 

--- a/src/ve/exceptions.cpp
+++ b/src/ve/exceptions.cpp
@@ -6,7 +6,7 @@
 
 using namespace HSharpVE;
 
-std::string HSharpVE::to_string(EExceptionSource source) {
+std::string HSharpVE::toString(EExceptionSource source) {
     switch (source) {
         HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, PARSER);
         HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, UTILITY);
@@ -16,7 +16,7 @@ std::string HSharpVE::to_string(EExceptionSource source) {
     }
 }
 
-std::string HSharpVE::to_string(EExceptionReason reason) {
+std::string HSharpVE::toString(EExceptionReason reason) {
     switch (reason) {
         HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, EARLY_EOF);
         HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, CAST_ERROR);
@@ -29,8 +29,8 @@ std::string HSharpVE::to_string(EExceptionReason reason) {
 }
 
 [[noreturn]] void HSharpVE::error(EExceptionSource source, EExceptionReason reason, std::string_view message) {
-    std::cerr << RED << '[' << to_string(source) << ']'
-              << ' ' << to_string(reason) << ": " << message 
+    std::cerr << RED << '[' << toString(source) << ']'
+              << ' ' << toString(reason) << ": " << message 
               << RESET;
     std::abort();
 }

--- a/src/ve/exceptions.cpp
+++ b/src/ve/exceptions.cpp
@@ -1,22 +1,36 @@
-#include <cstdio>
-#include <cstdlib>
+// STD
+#include <iostream>
 
-#include <boost/algorithm/string.hpp>
+// local
+#include <ve/exceptions.hpp>
 
-#include <ve/ve.hpp>
+using namespace HSharpVE;
 
-using HSharpVE::ExceptionSource;
-using HSharpVE::ExceptionType;
-
-[[noreturn]] void throwFatalException(ExceptionSource source, ExceptionType type, const char* message){
-    fputs("\033[31;1m", stderr);
-    fputs(boost::to_upper_copy(std::format("[{}]: ", HSharpVE::ToString(source))).c_str(), stderr);
-    fputs(std::format("{}: ", HSharpVE::ToString(type)).c_str(), stderr);
-    fputs(message, stderr);
-    fputs("\033[0m\n", stderr);
-    exit(1);
+std::string HSharpVE::to_string(EExceptionSource source) {
+    switch (source) {
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, PARSER);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, UTILITY);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, TOKENIZER);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionSource, VIRTUAL_ENV);
+        default: HSHARP_NOT_IMPLEMENTED(EExceptionSource::UTILITY, "enum value out of range");
+    }
 }
 
-[[noreturn]] void throwFatalException(ExceptionSource source, ExceptionType type, std::string& message) {
-    throwFatalException(source, type, message.c_str());
+std::string HSharpVE::to_string(EExceptionReason reason) {
+    switch (reason) {
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, EARLY_EOF);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, CAST_ERROR);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, TYPE_ERROR);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, SYNTAX_ERROR);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, NOT_IMPLEMENTED);
+        HSHARP_ENUM_CASE(HSharpVE::EExceptionReason, UNEXPECTED_TOKEN);
+        default: HSHARP_NOT_IMPLEMENTED(EExceptionSource::UTILITY, "Enum value out of range");
+    }
+}
+
+[[noreturn]] void HSharpVE::error(EExceptionSource source, EExceptionReason reason, std::string_view message) {
+    std::cerr << RED << '[' << to_string(source) << ']'
+              << ' ' << to_string(reason) << ": " << message 
+              << RESET;
+    std::abort();
 }

--- a/src/ve/ve_main.cpp
+++ b/src/ve/ve_main.cpp
@@ -2,33 +2,38 @@
 #include <string>
 #include <cstring>
 
+#include "ve/exceptions.hpp"
 #include <parser/parser.hpp>
 #include <ve/ve.hpp>
 
 using std::uint32_t;
 using std::string;
 
-/* All internal function bodies */
+/* All internal function definitions */
 void HSharpVE::VirtualEnvironment::StatementVisitor::operator()(HSharpParser::NodeStmtInput *stmt) const {
-    throwFatalException(ExceptionSource::VirtualEnv,
-                        ExceptionType::NotImplemented,
-                        "Not implemented: input()");
+    error(EExceptionSource::VIRTUAL_ENV,EExceptionReason::NOT_IMPLEMENTED,"input() is not implemented");
 }
+
 void HSharpVE::VirtualEnvironment::StatementVisitor::operator()(HSharpParser::NodeStmtPrint *stmt) const {
     parent->StatementVisitor_StatementPrint(stmt);
 }
+
 void HSharpVE::VirtualEnvironment::StatementVisitor::operator()(HSharpParser::NodeStmtExit *stmt) const {
     parent->StatementVisitor_StatementExit(stmt);
 }
+
 void HSharpVE::VirtualEnvironment::StatementVisitor::operator()(HSharpParser::NodeStmtVar *stmt) const {
     parent->StatementVisitor_StatementVar(stmt);
 }
+
 void HSharpVE::VirtualEnvironment::StatementVisitor::operator()(HSharpParser::NodeStmtVarAssign *stmt) const {
     parent->StatementVisitor_StatementVarAssign(stmt);
 }
+
 HSharp::ValueInfo HSharpVE::VirtualEnvironment::ExpressionVisitor::operator()(HSharpParser::NodeTerm *term) const {
     return std::visit(parent->termvisitor, term->term);
 }
+
 HSharp::ValueInfo HSharpVE::VirtualEnvironment::ExpressionVisitor::operator()(const HSharpParser::NodeExpressionStrLit *expr) const {
     auto str = static_cast<std::string*>(parent->strings_pool.malloc());
     str = new(str)std::string(expr->str_lit.value.value());
@@ -70,13 +75,9 @@ HSharp::ValueInfo HSharpVE::VirtualEnvironment::BinExprVisitor::operator()(const
     auto result = parent->integers_pool.malloc();
     ValueInfo lhs, rhs;
     if ((lhs = std::visit(parent->exprvisitor, expr->lhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     if ((rhs = std::visit(parent->exprvisitor, expr->rhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     *result = *static_cast<int64_t*>(lhs.value) + *static_cast<int64_t*>(rhs.value);
     parent->dispose_value(lhs);
     parent->dispose_value(rhs);
@@ -86,13 +87,9 @@ HSharp::ValueInfo HSharpVE::VirtualEnvironment::BinExprVisitor::operator()(const
     auto result = parent->integers_pool.malloc();
     ValueInfo lhs, rhs;
     if ((lhs = std::visit(parent->exprvisitor, expr->lhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     if ((rhs = std::visit(parent->exprvisitor, expr->rhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     *result = *static_cast<int64_t*>(lhs.value) - *static_cast<int64_t*>(rhs.value);
     parent->dispose_value(lhs);
     parent->dispose_value(rhs);
@@ -102,13 +99,9 @@ HSharp::ValueInfo HSharpVE::VirtualEnvironment::BinExprVisitor::operator()(const
     auto result = parent->integers_pool.malloc();
     ValueInfo lhs, rhs;
     if ((lhs = std::visit(parent->exprvisitor, expr->lhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     if ((rhs = std::visit(parent->exprvisitor, expr->rhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     *result = *static_cast<int64_t*>(lhs.value) * *static_cast<int64_t*>(rhs.value);
     parent->dispose_value(lhs);
     parent->dispose_value(rhs);
@@ -118,13 +111,9 @@ HSharp::ValueInfo HSharpVE::VirtualEnvironment::BinExprVisitor::operator()(const
     auto result = parent->integers_pool.malloc();
     ValueInfo lhs, rhs;
     if ((lhs = std::visit(parent->exprvisitor, expr->lhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     if ((rhs = std::visit(parent->exprvisitor, expr->rhs->expr)).type != VariableType::INT)
-        throwFatalException(ExceptionSource::VirtualEnv,
-                            ExceptionType::TypeError,
-                            "Binary expression evaluation impossible: invalid literal type");
+        error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Binary expression evaluation impossible: invalid literal type");
     *result = *static_cast<int64_t*>(lhs.value) / *static_cast<int64_t*>(rhs.value);
     parent->dispose_value(lhs);
     parent->dispose_value(rhs);
@@ -141,9 +130,7 @@ void HSharpVE::VirtualEnvironment::delete_var_value(HSharpVE::Variable &variable
             strings_pool.free(static_cast<string*>(variable.value));
             break;
         default:
-            throwFatalException(ExceptionSource::VirtualEnv,
-                                ExceptionType::TypeError,
-                                "Cannot delete value: invalid type");
+            error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Cannot delete value: invalid type");
     }
 }
 void* HSharpVE::VirtualEnvironment::allocate(HSharp::VariableType vtype) {
@@ -153,9 +140,7 @@ void* HSharpVE::VirtualEnvironment::allocate(HSharp::VariableType vtype) {
         case VariableType::STRING:
             return strings_pool.malloc();
         default:
-            throwFatalException(ExceptionSource::VirtualEnv,
-                                ExceptionType::TypeError,
-                                "Cannot allocate: invalid type");
+            error(EExceptionSource::VIRTUAL_ENV, EExceptionReason::TYPE_ERROR, "Cannot delete value: invalid type");
     }
 }
 void HSharpVE::VirtualEnvironment::exec_statement(const HSharpParser::NodeStmt* stmt) {


### PR DESCRIPTION
- errors, sources are now declared in enum classes with hints
- single function to handle errors
- no boost
- some convenience macros

Хотел бы generic советы дать:
- не стоит перегружать функции для char* и std::string, для этого есть просто std::string который совместим с char*, а также если ты передаешь константные строки (const char* или const std::string&) есть string_view
- старайся придерживаться единного стиля кода. Это не функциональный совет, просто намного проще воспринимать код, где все значения enum пишуться капсом, а не тут PascalCase, там капсом))
- enum кстати рекомендую именовать с заглавной E - от enum, т.е. например EValueType +  не повторяй смысл enum в переменных. Если enum называется EToken, то его значениями могут быть VARIABLE, TYPE. Значения типа TOKEN_VARIABLE повторяют смысл и делают код громоздким
- докопаюсь до нейминга последний раз: throwFatalException звучит неразумно т.к. любой exception базового - критическая ошибка. функцию лучше называть тогда error, fatal. Для функции без abort или terminate можно использовать названия типа warning, warn.
- для выхода из приложения тоже следует использовать единый стиль. Рекомендую пихать везде std::abort :) 